### PR TITLE
Make setjmp/longjmp calls always only use Thumb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 # Prep the git repos with no patches and any required libraries for gcc
 .stage.prepgit: .stage.download .clean.gits
 	echo STAGE: $@
-	for i in binutils-gdb gcc newlib mklittlefs pico-sdk openocd; do cd $(REPODIR)/$$i && git reset --hard HEAD && git submodule init && git submodule update && git clean -f -d; done > $(call log,$@) 2>&1
+	for i in $(BINUTILS_DIR) $(GCC_DIR) newlib mklittlefs pico-sdk openocd; do cd $(REPODIR)/$$i && git reset --hard HEAD && git submodule init && git submodule update && git clean -f -d; done > $(call log,$@) 2>&1
 	for url in $(GNUHTTP)/gmp-6.1.0.tar.bz2 $(GNUHTTP)/mpfr-3.1.4.tar.bz2 $(GNUHTTP)/mpc-1.0.3.tar.gz \
 	           $(GNUHTTP)/isl-$(ISL).tar.bz2 $(GNUHTTP)/cloog-0.18.1.tar.gz https://github.com/earlephilhower/pico-quick-toolchain/raw/master/blobs/libelf-0.8.13.tar.gz ; do \
 	    archive=$${url##*/}; name=$${archive%.t*}; base=$${name%-*}; ext=$${archive##*.} ; \

--- a/patches/lib-setjmp-thumb.patch
+++ b/patches/lib-setjmp-thumb.patch
@@ -1,0 +1,13 @@
+diff --git a/newlib/libc/machine/arm/setjmp.S b/newlib/libc/machine/arm/setjmp.S
+index 21d6ff9e7..6e337842c 100644
+--- a/newlib/libc/machine/arm/setjmp.S
++++ b/newlib/libc/machine/arm/setjmp.S
+@@ -59,7 +59,7 @@
+ 
+        .syntax unified
+ 
+-#if __ARM_ARCH_ISA_THUMB == 1 && !__ARM_ARCH_ISA_ARM
++#if 1
+ /* ARMv6-M-like has to be implemented in Thumb mode.  */
+ 
+ .thumb


### PR DESCRIPTION
The Cortex-M0+ doesn't support anything but Thumb mode, so ensure the
setjmp.S file doesn't use the standard versions of the instructions.