### PR TITLE
Enable retargetable locks in newlib, fix multicore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ CONFIGURENEWLIBCOM += --target=$(ARCH)
 CONFIGURENEWLIBCOM += --disable-shared
 CONFIGURENEWLIBCOM += --with-cpu=cortex-m0plus
 CONFIGURENEWLIBCOM += --with-no-thumb-interwork
+CONFIGURENEWLIBCOM += --enable-newlib-retargetable-locking
 
 # Configuration for newlib normal build
 configurenewlib  = --prefix=$(call install,$(1))

--- a/patches/lib-weak-locks.patch
+++ b/patches/lib-weak-locks.patch
@@ -1,0 +1,88 @@
+diff --git a/newlib/libc/misc/lock.c b/newlib/libc/misc/lock.c
+index 545511e78..984b51f72 100644
+--- a/newlib/libc/misc/lock.c
++++ b/newlib/libc/misc/lock.c
+@@ -92,63 +92,73 @@ struct __lock {
+   char unused;
+ };
+ 
+-struct __lock __lock___sinit_recursive_mutex;
+-struct __lock __lock___sfp_recursive_mutex;
+-struct __lock __lock___atexit_recursive_mutex;
+-struct __lock __lock___at_quick_exit_mutex;
+-struct __lock __lock___malloc_recursive_mutex;
+-struct __lock __lock___env_recursive_mutex;
+-struct __lock __lock___tz_mutex;
+-struct __lock __lock___dd_hash_mutex;
+-struct __lock __lock___arc4random_mutex;
+-
++struct __lock __lock___sinit_recursive_mutex __attribute__((weak));
++struct __lock __lock___sfp_recursive_mutex __attribute__((weak));
++struct __lock __lock___atexit_recursive_mutex __attribute__((weak));
++struct __lock __lock___at_quick_exit_mutex __attribute__((weak));
++struct __lock __lock___malloc_recursive_mutex __attribute__((weak));
++struct __lock __lock___env_recursive_mutex __attribute__((weak));
++struct __lock __lock___tz_mutex __attribute__((weak));
++struct __lock __lock___dd_hash_mutex __attribute__((weak));
++struct __lock __lock___arc4random_mutex __attribute__((weak));
++
++void __retarget_lock_init (_LOCK_T *lock) __attribute__((weak));
+ void
+ __retarget_lock_init (_LOCK_T *lock)
+ {
+ }
+ 
++void __retarget_lock_init_recursive(_LOCK_T *lock) __attribute__((weak));
+ void
+ __retarget_lock_init_recursive(_LOCK_T *lock)
+ {
+ }
+ 
++void __retarget_lock_close(_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_close(_LOCK_T lock)
+ {
+ }
+ 
++void __retarget_lock_close_recursive(_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_close_recursive(_LOCK_T lock)
+ {
+ }
+ 
++void __retarget_lock_acquire (_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_acquire (_LOCK_T lock)
+ {
+ }
+ 
++void __retarget_lock_acquire_recursive (_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_acquire_recursive (_LOCK_T lock)
+ {
+ }
+ 
++int __retarget_lock_try_acquire(_LOCK_T lock) __attribute__((weak));
+ int
+ __retarget_lock_try_acquire(_LOCK_T lock)
+ {
+   return 1;
+ }
+ 
++int __retarget_lock_try_acquire_recursive(_LOCK_T lock) __attribute__((weak));
+ int
+ __retarget_lock_try_acquire_recursive(_LOCK_T lock)
+ {
+   return 1;
+ }
+ 
++void __retarget_lock_release (_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_release (_LOCK_T lock)
+ {
+ }
+ 
++void __retarget_lock_release_recursive (_LOCK_T lock) __attribute__((weak));
+ void
+ __retarget_lock_release_recursive (_LOCK_T lock)
+ {

--- a/post/10.3-clean-libgcc.sh
+++ b/post/10.3-clean-libgcc.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-
+#ext=$1
+#find arm-none-eabi${$ext} -name libc.a -exec ./arm-none-eabi.x86_64/bin/xtensa-lx106-elf-gcc-ar d \{\} lib_a-lock.o \;


### PR DESCRIPTION
Newlib allows for stubs for protecting critical sections.  Enable them
and allow them to be overridden by the end user (to support SDK or
FreeRTOS mutexes).