### PR TITLE
Add armv7l as system to RPi builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ RPI_BFLGS  := LDFLAGS=-static
 RPI_TARCMD := tar
 RPI_TAROPT := zcf
 RPI_TAREXT := tar.gz
-RPI_ASYS   := linux_armv6l
+RPI_ASYS   := linux_armv6l\",\ \"linux_armv7l
 RPI_DEB    := armhf
 
 # Call with $@ to get the appropriate variable for this architecture


### PR DESCRIPTION
PlatformIO refuses to install the armv6l builds on armv7l systems (such as the Pi3 with 32bit OS). Manually installing these using packages with modified package.json works fine and this should add linux_armv7l as a supported to system to RPi builds, hopefully avoiding this issue. This is likely the cause of #6 and I'm hoping that this will make the package install from the platformio repository. Even if that fails, this should allow direct linking to release builds in platform.ini which is much easier than manually modifying the package.json file in all builds (and telling others to do the same when they want to build the firmware).