### PR TITLE
Add FLOCK patch, fix FILE I/O, document builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,9 @@ makejson = tarballsize=$$(stat -c%s $${tarball}); \
 	     echo ' "size": "'$${tarballsize}'"' && \
 	     echo '}') > $${tarball}.json
 
+# Dummp all the git hashed/tags being built
+makegitlog = for i in binutils-gdb-gnu gcc-gnu mklittlefs newlib openocd pico-sdk picotool; do (cd $(REPODIR)/$$i && echo -n $$i: && git describe --tags --always); done
+
 # The recpies begin here.
 
 linux default: .stage.LINUX.done
@@ -522,7 +525,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	cp -a $(call install,$@) pkg.$(call arch,$@)/$(ARCH) >> $(call log,$@) 2>&1
 	(cd pkg.$(call arch,$@)/$(ARCH); $(call setenv,$@); pkgdesc="$(ARCH)-gcc"; pkgname="toolchain-rp2040-earlephilhower"; $(call makepackagejson,$@)) >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).$(ARCH)-$$(git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd pkg.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} $(ARCH)/ ; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd pkg.$(call arch,$@) && cp -a $(PATCHDIR) $(ARCH)/. && $(call makegitlog) > $(ARCH)/gitlog.txt && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} $(ARCH)/ ; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf pkg.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 
@@ -540,7 +543,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	(cd pkg.mklittlefs.$(call arch,$@)/mklittlefs; $(call setenv,$@); pkgdesc="littlefs-utility"; pkgname="tool-mklittlefs-rp2040-earlephilhower"; $(call makepackagejson,$@)) >> $(call log,$@) 2>&1
 	cp $(call arena,$@)/mklittlefs/mklittlefs$(call exe,$@) pkg.mklittlefs.$(call arch,$@)/mklittlefs/. >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).mklittlefs-$$(cd $(REPODIR)/mklittlefs && git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd pkg.mklittlefs.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} mklittlefs; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd pkg.mklittlefs.$(call arch,$@) && $(call makegitlog) > mklittlefs/gitlog.txt && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} mklittlefs; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf pkg.mklittlefs.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 
@@ -555,7 +558,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	$(call host,$@)-strip $(call arena,$@)/elf2uf2/elf2uf2$(call exe,$@) >> $(call log,$@) 2>&1
 	cp $(call arena,$@)/elf2uf2/elf2uf2$(call exe,$@) pkg.elf2uf2.$(call arch,$@)/elf2uf2/. >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).elf2uf2-$$(cd $(REPODIR)/pico-sdk && git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd pkg.elf2uf2.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} elf2uf2; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd pkg.elf2uf2.$(call arch,$@) && $(call makegitlog) > elf2uf2/gitlog.txt && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} elf2uf2; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf pkg.elf2uf2.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 
@@ -570,7 +573,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	$(call host,$@)-strip $(call arena,$@)/pioasm/pioasm$(call exe,$@) >> $(call log,$@) 2>&1
 	cp $(call arena,$@)/pioasm/pioasm$(call exe,$@) pkg.pioasm.$(call arch,$@)/pioasm/. >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).pioasm-$$(cd $(REPODIR)/pico-sdk && git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd pkg.pioasm.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} pioasm; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd pkg.pioasm.$(call arch,$@) && $(call makegitlog) > pioasm/gitlog.txt && $(call tarcmd,$@) $(call taropt,$@) ../$${tarball} pioasm; cd ..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf pkg.pioasm.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 
@@ -597,11 +600,11 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	(cd $(call arena,$@)/picotool && make -j4 && mkdir -p $(call arena,$@)/pkg.picotool.$(call arch,$@)/picotool && cp picotool $(REPODIR)/picotool/LICENSE.TXT $(call arena,$@)/pkg.picotool.$(call arch,$@)/picotool/.) >> $(call log,$@) 2>&1
 	(cd $(call arena,$@)/pkg.picotool.$(call arch,$@)/picotool; $(call setenv,$@); pkgdesc="picotool-utility"; pkgname="tool-picotool-rp2040-earlephilhower"; $(call makepackagejson,$@)) >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).picotool-$$(cd $(REPODIR)/picotool && git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd $(call arena,$@)/pkg.picotool.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../../$${tarball} picotool; cd ../..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd $(call arena,$@)/pkg.picotool.$(call arch,$@) && $(call makegitlog) > picotool/gitlog.txt && $(call tarcmd,$@) $(call taropt,$@) ../../$${tarball} picotool; cd ../..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf $(call arena,$@)/pkg.picotool.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 
-# These archs use manually build openocd executables
+# These archs use manually build picotool executables
 .stage.WIN32.picotool: .stage.WIN32.start
 .stage.WIN64.picotool: .stage.WIN64.start
 .stage.OSX.picotool: .stage.OSX.start
@@ -674,7 +677,7 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	(cd $(call arena,$@)/openocd && make -j4 && make install) >> $(call log,$@) 2>&1
 	(cd $(call arena,$@)/pkg.openocd.$(call arch,$@)/openocd; $(call setenv,$@); pkgdesc="openocd-utility"; pkgname="tool-openocd-rp2040-earlephilhower"; $(call makepackagejson,$@)) >> $(call log,$@) 2>&1
 	(tarball=$(call host,$@).openocd-$$(cd $(REPODIR)/openocd && git rev-parse --short HEAD).$(STAMP).$(call tarext,$@) ; \
-	    cd $(call arena,$@)/pkg.openocd.$(call arch,$@) && $(call tarcmd,$@) $(call taropt,$@) ../../$${tarball} openocd; cd ../..; $(call makejson,$@)) >> $(call log,$@) 2>&1
+	    cd $(call arena,$@)/pkg.openocd.$(call arch,$@) && $(call makegitlog) > openocd/gitlog.txt && cp -a $(PATCHDIR) openocd/. && $(call tarcmd,$@) $(call taropt,$@) ../../$${tarball} openocd; cd ../..; $(call makejson,$@)) >> $(call log,$@) 2>&1
 	rm -rf $(call arena,$@)/pkg.openocd.$(call arch,$@) >> $(call log,$@) 2>&1
 	touch $@
 

--- a/patches/lib-flockt.patch
+++ b/patches/lib-flockt.patch
@@ -1,0 +1,57 @@
+diff --git a/newlib/libc/include/sys/reent.h b/newlib/libc/include/sys/reent.h
+index 74b70e9c0..f5294812d 100644
+--- a/newlib/libc/include/sys/reent.h
++++ b/newlib/libc/include/sys/reent.h
+@@ -32,7 +32,7 @@ typedef unsigned __Long __ULong;
+ 
+ #ifndef __machine_flock_t_defined
+ #include <sys/lock.h>
+-typedef _LOCK_RECURSIVE_T _flock_t;
++typedef struct __lock _flock_t;
+ #endif
+ 
+ #ifndef __Long
+diff --git a/newlib/libc/include/sys/lock.h b/newlib/libc/include/sys/lock.h
+index 528904957..0653c77fd 100644
+--- a/newlib/libc/include/sys/lock.h
++++ b/newlib/libc/include/sys/lock.h
+@@ -30,7 +30,7 @@ typedef int _LOCK_RECURSIVE_T;
+ extern "C" {
+ #endif
+ 
+-struct __lock;
++struct __lock { long long x; };
+ typedef struct __lock * _LOCK_T;
+ #define _LOCK_RECURSIVE_T _LOCK_T
+ 
+@@ -45,7 +45,7 @@ extern void __retarget_lock_init_recursive(_LOCK_T *lock);
+ extern void __retarget_lock_close(_LOCK_T lock);
+ #define __lock_close(lock) __retarget_lock_close(lock)
+ extern void __retarget_lock_close_recursive(_LOCK_T lock);
+-#define __lock_close_recursive(lock) __retarget_lock_close_recursive(lock)
++#define __lock_close_recursive(lock) __retarget_lock_close_recursive(&lock)
+ extern void __retarget_lock_acquire(_LOCK_T lock);
+ #define __lock_acquire(lock) __retarget_lock_acquire(lock)
+ extern void __retarget_lock_acquire_recursive(_LOCK_T lock);
+diff --git a/newlib/libc/include/sys/stdio.h b/newlib/libc/include/sys/stdio.h
+index 91a274596..af3fd255a 100644
+--- a/newlib/libc/include/sys/stdio.h
++++ b/newlib/libc/include/sys/stdio.h
+@@ -10,7 +10,7 @@
+    set then do nothing as lock is not initialised. */
+ #if !defined(_flockfile)
+ #ifndef __SINGLE_THREAD__
+-#  define _flockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_acquire_recursive((fp)->_lock))
++#  define _flockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_acquire_recursive(&((fp)->_lock)))
+ #else
+ #  define _flockfile(fp)       ((void) 0)
+ #endif
+@@ -18,7 +18,7 @@
+ 
+ #if !defined(_funlockfile)
+ #ifndef __SINGLE_THREAD__
+-#  define _funlockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_release_recursive((fp)->_lock))
++#  define _funlockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_release_recursive(&((fp)->_lock)))
+ #else
+ #  define _funlockfile(fp)     ((void) 0)
+ #endif


### PR DESCRIPTION
Re-introduce the file lock patch from earlier.  W/O it the size set aside for the file lock is 4 bytes, but we need a recursive mutex of 8 bytes so we end up with data corruption.

Bring a copy of the patches and log of all git versions in the packaged tarballs to make it clear what was/was not included in a run.