### PR TITLE
newlib: define _POSIX_TIMERS to 0 for micro-ROS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ install = $(call arena,$(1))/$(ARCH)
 BLOBS = $(PWD)/blobs
 
 # GNU infra
-GMP_VER := 6.1.2
+GMP_VER := 6.2.1
 
 # RPI stuff
 PICOSDK_BRANCH  := 2.0.0

--- a/patches/lib-posix-timers.patch
+++ b/patches/lib-posix-timers.patch
@@ -1,0 +1,15 @@
+diff --git a/newlib/libc/include/sys/features.h b/newlib/libc/include/sys/features.h
+index 325acdf5f..b0c22e16c 100644
+--- a/newlib/libc/include/sys/features.h
++++ b/newlib/libc/include/sys/features.h
+@@ -570,6 +570,10 @@ extern "C" {
+ 
+ #endif /* __CYGWIN__ */
+ 
++#ifndef _POSIX_TIMERS
++#define _POSIX_TIMERS 0
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif


### PR DESCRIPTION
micro-ROS uses clock_gettime() and added a custom one when there is no real posix timers support. The latest newlib missed the func proto and caused build error. This patch fixed this issue. Tested on both pico and pico2.

In this timer.h
    #if defined(_POSIX_TIMERS)
    ...
    int clock_settime (clockid_t clock_id, const struct timespec *tp);
    int clock_gettime (clockid_t clock_id, struct timespec *tp);